### PR TITLE
Add missing next-tick module

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "web audio"
   ],
   "dependencies": {
-    "through": "~2.3.4"
+    "through": "~2.3.4",
+    "next-tick": "^0.2.2"
   },
   "author": "Matt McKegg",
   "license": "MIT"


### PR DESCRIPTION
When I tried to run the ditty example it informed me about the missing next-tick module in bopper. So I added it ;)
